### PR TITLE
revise Bebop configuration for October 2021

### DIFF
--- a/ANL/Bebop/README.md
+++ b/ANL/Bebop/README.md
@@ -5,18 +5,17 @@ Bebop
 Programming environment
 -----------------------
 
-The Bebop machine has many compilers and MPI implementations, not all
-of which work correctly with Mochi. We have found `gcc@8.2.0` with
-the `intel-mpi` package to be the most reliable way of working with
-Mochi on this platform. You can work with these packages by typping:
+Before using Spack to compile Mochi on Bebop, we recommend the following
+changes to your environment:
 
-```
-$ module load gcc/8.2.0-g7hppkz
-```
-
-This command will automatically change the compiler to `gcc@8.2.0`
-and change the `intel-mpi` package to the appropriate one.
-
+- `module load gcc`
+  - this will change the default compiler from Intel (icc) to GNU (gcc) and
+    load a matching Intel MPI library.  We recommend compiling Mochi packages
+    using gcc
+- `module load anaconda3`
+  - this will change the default Python interpreter from version 2.x to
+    version 3.x. Either one will work with Spack, but the former will emit
+    warnings due to missing features.
 
 Networking
 ----------

--- a/ANL/Bebop/spack.yaml
+++ b/ANL/Bebop/spack.yaml
@@ -1,31 +1,29 @@
 spack:
   specs:
-  - mochi-margo%gcc@8.2.0
-  - mercury@master%gcc@8.2.0
+  - mochi-margo%gcc@10.2.0
+  - mercury%gcc@10.2.0
   concretization: together
   compilers:
   - compiler:
       paths:
-        cc: /blues/gpfs/software/centos7/spack/opt/spack/linux-centos7-x86_64/gcc-8.1.0/gcc-8.2.0-g7hppkz/bin/gcc
-        cxx: /blues/gpfs/software/centos7/spack/opt/spack/linux-centos7-x86_64/gcc-8.1.0/gcc-8.2.0-g7hppkz/bin/g++
-        f77: /blues/gpfs/software/centos7/spack/opt/spack/linux-centos7-x86_64/gcc-8.1.0/gcc-8.2.0-g7hppkz/bin/gfortran
-        fc: /blues/gpfs/software/centos7/spack/opt/spack/linux-centos7-x86_64/gcc-8.1.0/gcc-8.2.0-g7hppkz/bin/gfortran
+        cc: /gpfs/fs1/software/centos7/spack-latest/opt/spack/linux-centos7-x86_64/gcc-6.5.0/gcc-10.2.0-z53hda3/bin/gcc
+        cxx: /gpfs/fs1/software/centos7/spack-latest/opt/spack/linux-centos7-x86_64/gcc-6.5.0/gcc-10.2.0-z53hda3/bin/g++
+        f77: /gpfs/fs1/software/centos7/spack-latest/opt/spack/linux-centos7-x86_64/gcc-6.5.0/gcc-10.2.0-z53hda3/bin/gfortran
+        fc: /gpfs/fs1/software/centos7/spack-latest/opt/spack/linux-centos7-x86_64/gcc-6.5.0/gcc-10.2.0-z53hda3/bin/gfortran
       operating_system: centos7
       target: x86_64
-      modules:
-      - gcc/8.2.0-g7hppkz
-      - intel-mpi/2018.4.274-ozfo327
+      modules: []
       environment: {}
       extra_rpaths: []
       flags: {}
-      spec: gcc@8.2.0
+      spec: gcc@10.2.0
   repos:
-  - path/to/sds-repo
+  - /path/to/mochi-spack-packages
   packages:
     all:
       providers:
         mpi: [ intel-mpi ]
-      compiler: [ gcc@8.2.0 ]
+      compiler: [ gcc@10.2.0 ]
     autoconf:
       buildable: false
       version: []
@@ -78,9 +76,9 @@ spack:
       compiler: []
       providers: {}
       externals:
-      - spec: cmake@3.14.2 arch=linux-centos7-x86_64
+      - spec: cmake@3.18.4 arch=linux-centos7-x86_64
         modules:
-        - cmake/3.14.2-gvwazz3
+        - cmake/3.18.4-fygx2f7
     coreutils:
       buildable: false
       version: []


### PR DESCRIPTION
misc updates:
- switch to gcc 10.2
- recommend python3 in initial environment
- use release version of mercury instead of mercury@master
- add leading backslash to stub repo path (otherwise `spack repo rm` will not remove it)
- rename sds-repo to mochi-spack-packages in stub repo path to clarify what it should point to
- use newer cmake