### PR TITLE
Bebop updates

### DIFF
--- a/ANL/Bebop/README.md
+++ b/ANL/Bebop/README.md
@@ -12,12 +12,24 @@ changes to your environment:
   - this will change the default compiler from Intel (icc) to GNU (gcc) and
     load a matching Intel MPI library.  We recommend compiling Mochi packages
     using gcc
+- `module load intel-mpi`
+  - this will insure that the MPI module is reactivated after loading gcc
 
 Networking
 ----------
 
-Bebop uses an Intel Omnipath fabric. The corresponding transport in
-Mercury is `ofi+psm2`, using the `+psm2` variant in `libfabric`.
+Bebop uses an Intel Omnipath fabric. There are currently three options for
+how to use this fabric in Mochi. Until Mercury 2.2.0 is release and available
+in Spack, it is necessary to install mercury@master to gain access to all 
+three:
+
+- "ofi+psm2://", using the `+psm2` variant in `libfabric`
+  - this is the traditional psm2 provider in libfabric
+- "psm2://", using the `+psm2` variant in `mercury`
+  - this is the native psm2 na plugin in Mercury
+- "ofi+opx://", using the `+opx` variant in `libfabric`
+  - this is the newer, and more experimental, OmniPath Express provider
+    in libfabric
 
 The `PSM2_MULTI_EP` environment variable should be set to 1 in your job script
 to avoid conflict between MPI and Mercury when using the PSM2 network.

--- a/ANL/Bebop/spack.yaml
+++ b/ANL/Bebop/spack.yaml
@@ -1,8 +1,6 @@
 spack:
   specs:
   - mochi-margo%gcc@10.2.0
-  - mercury%gcc@10.2.0
-  concretization: together
   compilers:
   - compiler:
       paths:
@@ -147,7 +145,7 @@ spack:
         modules:
         - intel-mpi/2019.8.254-hviu7j6
     libfabric:
-      variants: fabrics=psm2,sockets
+      variants: fabrics=psm2,opx,tcp,rxm
       version: []
       target: []
       compiler: []
@@ -173,8 +171,8 @@ spack:
       - spec: m4@1.4.16 arch=linux-centos7-x86_64
         prefix: /usr
     mercury:
-      variants: ~boostsys ~checksum
-      version: []
+      variants: ~boostsys ~checksum +psm2
+      version: [ master ]
       target: []
       compiler: []
       buildable: true


### PR DESCRIPTION
- make all omnipath drivers available, at least for experimental use
- remove explicit mercury root spec
- remove deprecated concretization directive