### PR TITLE
apply LD_LIBRARY_PATH settings uniformly

### DIFF
--- a/ANL/Bebop/spack.yaml
+++ b/ANL/Bebop/spack.yaml
@@ -19,6 +19,10 @@ spack:
       spec: gcc@10.2.0
   repos:
   - /path/to/mochi-spack-packages
+  modules:
+    prefix_inspections:
+      lib: [LD_LIBRARY_PATH]
+      lib64: [LD_LIBRARY_PATH]
   packages:
     all:
       providers:

--- a/ANL/Cooley/spack.yaml
+++ b/ANL/Cooley/spack.yaml
@@ -18,6 +18,10 @@ spack:
       extra_rpaths: []
   repos:
   - /path/to/mochi-spack-packages
+  modules:
+    prefix_inspections:
+      lib: [LD_LIBRARY_PATH]
+      lib64: [LD_LIBRARY_PATH]
   packages:
     autoconf:
       externals:

--- a/ANL/JLSE/spack.yaml
+++ b/ANL/JLSE/spack.yaml
@@ -20,6 +20,10 @@ spack:
       target: x86_64
   repos:
   - /path/to/mochi-spack-packages
+  modules:
+    prefix_inspections:
+      lib: [LD_LIBRARY_PATH]
+      lib64: [LD_LIBRARY_PATH]
   packages:
     all:
       providers:

--- a/ANL/Theta/spack.yaml
+++ b/ANL/Theta/spack.yaml
@@ -20,6 +20,10 @@ spack:
       spec: gcc@9.3.0
   repos:
   - /path/to/mochi-spack-packages
+  modules:
+    prefix_inspections:
+      lib: [LD_LIBRARY_PATH]
+      lib64: [LD_LIBRARY_PATH]
   packages:
     all:
       providers:

--- a/ANL/ThetaGPU/spack.yaml
+++ b/ANL/ThetaGPU/spack.yaml
@@ -3,6 +3,10 @@ spack:
   - mochi-margo
   repos:
   - /path/to/mochi-spack-packages
+  modules:
+    prefix_inspections:
+      lib: [LD_LIBRARY_PATH]
+      lib64: [LD_LIBRARY_PATH]
   packages:
     m4:
       externals:

--- a/NERSC/Cori/spack.yaml
+++ b/NERSC/Cori/spack.yaml
@@ -18,6 +18,10 @@ spack:
       spec: gcc@11.2.0
   repos:
   - /path/to/mochi-spack-packages
+  modules:
+    prefix_inspections:
+      lib: [LD_LIBRARY_PATH]
+      lib64: [LD_LIBRARY_PATH]
   packages:
     all:
       providers:

--- a/NERSC/Perlmutter/ss10/spack.yaml
+++ b/NERSC/Perlmutter/ss10/spack.yaml
@@ -26,6 +26,10 @@ spack:
       - libfabric
       environment: {}
       extra_rpaths: []
+  modules:
+    prefix_inspections:
+      lib: [LD_LIBRARY_PATH]
+      lib64: [LD_LIBRARY_PATH]
   packages:
     all:
       providers:

--- a/NERSC/Perlmutter/ss11/spack.yaml
+++ b/NERSC/Perlmutter/ss11/spack.yaml
@@ -26,6 +26,10 @@ spack:
       - libfabric/1.15.0.0
       environment: {}
       extra_rpaths: []
+  modules:
+    prefix_inspections:
+      lib: [LD_LIBRARY_PATH]
+      lib64: [LD_LIBRARY_PATH]
   packages:
     all:
       providers:

--- a/ORNL/Crusher/spack.yaml
+++ b/ORNL/Crusher/spack.yaml
@@ -4,6 +4,10 @@ spack:
   concretization: together
   repos:
   - /path/to/mochi-spack-packages
+  modules:
+    prefix_inspections:
+      lib: [LD_LIBRARY_PATH]
+      lib64: [LD_LIBRARY_PATH]
   packages:
     libfabric:
       externals:

--- a/ORNL/Summit/spack.yaml
+++ b/ORNL/Summit/spack.yaml
@@ -18,6 +18,10 @@ spack:
        extra_rpaths: []
   repos:
   - /path/to/mochi-spack-packages
+  modules:
+    prefix_inspections:
+      lib: [LD_LIBRARY_PATH]
+      lib64: [LD_LIBRARY_PATH]
   packages:
     all:
       compiler: [gcc@9.1.0]


### PR DESCRIPTION
Update spack environment example for every platform to export LD_LIBRARY_PATH by default to make sure that Mochi libraries are available at runtime regardless of Spack policy.

These settings were already in place and tested in the Polaris and generic environments; just copying same settings to other recipes. 