### PR TITLE
workaround spack problem with openmpi on thetagpu

### DIFF
--- a/ANL/ThetaGPU/spack.yaml
+++ b/ANL/ThetaGPU/spack.yaml
@@ -102,6 +102,7 @@ spack:
       providers: {}
       externals:
       - spec: openmpi@4.0.5
+        prefix: /lus/theta-fs0/software/thetagpu/openmpi-4.0.5
         modules:
         - openmpi/openmpi-4.0.5
     mercury:


### PR DESCRIPTION
- this fixes the "Query of package 'openmpi' for 'headers' failed" build error by explicitly specifying openmpi prefix

FYI @jhendersonHDF and @vchoi-hdfgroup