### PR TITLE
remove arch specifier for cray-mpich external

### DIFF
--- a/ANL/Polaris/spack-ucx.yaml
+++ b/ANL/Polaris/spack-ucx.yaml
@@ -48,7 +48,7 @@ spack:
       compiler: []
       providers: {}
       externals:
-      - spec: cray-mpich@8.1.16 arch=cray-sles15-zen3
+      - spec: cray-mpich@8.1.16
         modules:
         - cray-mpich/8.1.16
     mercury:

--- a/ANL/Polaris/spack.yaml
+++ b/ANL/Polaris/spack.yaml
@@ -48,7 +48,7 @@ spack:
       compiler: []
       providers: {}
       externals:
-      - spec: cray-mpich@8.1.16 arch=cray-sles15-zen3
+      - spec: cray-mpich@8.1.16
         modules:
         - cray-mpich/8.1.16
     mercury:


### PR DESCRIPTION
This was causing builds with packages that depended on MPI to select the wrong MPI library (e.g. openmpi or mpich rather than cray-mpich) because the arch specification is not correct for Polaris's current system image.
 
FYI @jhendersonHDF , @vchoi-hdfgroup and @hyoklee .  I don't know if this impacted your mobject builds on Polaris or not, but there was an error in the example spack environment files that was preventing Spack from using the system MPI library correctly, at least for the version of Spack that I am using.