### PR TITLE
Fix duplicated key in Polaris spack.yaml

### DIFF
--- a/ANL/Polaris/spack.yaml
+++ b/ANL/Polaris/spack.yaml
@@ -63,6 +63,7 @@ spack:
       - spec: libfabric@1.11.0.4.125
         modules:
         - libfabric/1.11.0.4.125
+      variants: fabrics=verbs,rxm +cuda
       buildable: true
       version: []
       target: []
@@ -118,13 +119,6 @@ spack:
       externals:
       - spec: m4@1.4.18
         prefix: /usr
-    libfabric:
-      variants: fabrics=verbs,rxm +cuda
-      version: []
-      target: []
-      compiler: []
-      buildable: true
-      providers: {}
     rdma-core:
       externals:
       - spec: rdma-core@20


### PR DESCRIPTION
@carns,

I had to wipe out my Spack clone and start anew to fix some compilation issues for Margo on Polaris. After I did that Spack was complaining to me about duplicate keys in the spack.yaml file here.