### PR TITLE
add zlib to polaris recipe

### DIFF
--- a/ANL/Polaris/spack.yaml
+++ b/ANL/Polaris/spack.yaml
@@ -83,6 +83,12 @@ spack:
       - spec: openssl@1.1.1d
         prefix: /usr
     m4:
+      buildable: false
       externals:
       - spec: m4@1.4.18
+        prefix: /usr
+    zlib:
+      buildable: false
+      externals:
+      - spec: zlib@1.2.11
         prefix: /usr


### PR DESCRIPTION
zlib is a dependency of some mochi packages but if built from scratch it is likely to conflict with the version on Polaris.

Also fix typo; m4 package should be explicitly marked as non-buildable.