### PR TITLE
revised sunspot recipe as of 2024-04

### DIFF
--- a/ANL/Sunspot/spack.yaml
+++ b/ANL/Sunspot/spack.yaml
@@ -5,7 +5,7 @@
 spack:
   # add package specs to the `specs` list
   specs:
-    - mochi-margo
+  - mochi-margo
   view: true
   modules:
     prefix_inspections:
@@ -13,33 +13,45 @@ spack:
       lib64: [LD_LIBRARY_PATH]
   compilers:
   - compiler:
-      spec: oneapi@2023.05.15.006.001
+      spec: oneapi@2023.12.15.002
       paths:
-        cc: /soft/restricted/CNDA/updates/2023.05.15.001/oneapi/compiler/eng-20230512/compiler/linux/bin/icx
-        cxx: /soft/restricted/CNDA/updates/2023.05.15.001/oneapi/compiler/eng-20230512/compiler/linux/bin/icpx
-        f77: /soft/restricted/CNDA/updates/2023.05.15.001/oneapi/compiler/eng-20230512/compiler/linux/bin/ifx
-        fc: /soft/restricted/CNDA/updates/2023.05.15.001/oneapi/compiler/eng-20230512/compiler/linux/bin/ifx
+        cc: /opt/aurora/23.275.2/CNDA/oneapi/compiler/eng-20231130/bin/icx
+        cxx: /opt/aurora/23.275.2/CNDA/oneapi/compiler/eng-20231130/bin/icpx
+        f77: /opt/aurora/23.275.2/CNDA/oneapi/compiler/eng-20231130/bin/ifx
+        fc: /opt/aurora/23.275.2/CNDA/oneapi/compiler/eng-20231130/bin/ifx
       flags: {}
       operating_system: sles15
       target: x86_64
       modules:
-        - oneapi-prgenv/2023.05.15.006.001
+      - oneapi/eng-compiler/2023.12.15.002
+  - compiler:
+      spec: gcc@=12.2.0
+      paths:
+        cc: /opt/aurora/23.275.2/spack/gcc/0.6.1/install/linux-sles15-x86_64/gcc-12.2.0/gcc-12.2.0-jf4ov3v3scg7dvd76qhsuugl3jp42gfn/bin/gcc
+        cxx: /opt/aurora/23.275.2/spack/gcc/0.6.1/install/linux-sles15-x86_64/gcc-12.2.0/gcc-12.2.0-jf4ov3v3scg7dvd76qhsuugl3jp42gfn/bin/g++
+        f77: /opt/aurora/23.275.2/spack/gcc/0.6.1/install/linux-sles15-x86_64/gcc-12.2.0/gcc-12.2.0-jf4ov3v3scg7dvd76qhsuugl3jp42gfn/bin/gfortran
+        fc: /opt/aurora/23.275.2/spack/gcc/0.6.1/install/linux-sles15-x86_64/gcc-12.2.0/gcc-12.2.0-jf4ov3v3scg7dvd76qhsuugl3jp42gfn/bin/gfortran
+      flags: {}
+      operating_system: sles15
+      target: x86_64
+      modules: []
+      environment: {}
+      extra_rpaths: []
   packages:
     all:
       providers:
-        mpi: [ mpich ]
-      compiler:
-      - dpcpp@2023.2.0
+        mpi: [mpich]
       target:
       - x86_64
       buildable: true
     mpich:
       externals:
-      - spec: mpich@51.2 %oneapi@2023.05.15.006.001
-        prefix: /soft/restricted/CNDA/updates/mpich/51.2/mpich-ofi-all-icc-default-pmix-gpu-drop51
+      - spec: mpich@52.2 %oneapi@2023.12.15.002
+        prefix: /opt/aurora/23.275.2/CNDA/mpich/52.2/mpich-ofi-all-icc-default-pmix-gpu-drop52/
         modules:
-          - mpich/51.2/icc-all-pmix-gpu
-          - intel_compute_runtime/release/agama-devel-647
+        - mpich/icc-all-pmix-gpu/52.2
+        - intel_compute_runtime/release/agama-devel-736.25
+        - oneapi/eng-compiler/2023.12.15.002
       buildable: false
 # NOTE: the +hwloc variant for Mercury configures it to be able to
 # automatically select NICs based on hardware topology
@@ -50,7 +62,7 @@ spack:
 # workaround for faulty pmix library dependencies on Sunspot.  We can return to # official releases when the next version > 0.5.3 is available
     mochi-ssg:
       buildable: true
-      version: [ main ]
+      version: [main]
     libfabric:
       externals:
       - spec: libfabric@1.15.2.0


### PR DESCRIPTION
- update oneapi compiler version
- update mpich version
- remove extra compilers except for current gcc and oneapi
- add oneapi module dependency in mpich external spec