### PR TITLE
more externals for sunspot

### DIFF
--- a/ANL/Sunspot/spack.yaml
+++ b/ANL/Sunspot/spack.yaml
@@ -64,11 +64,11 @@ spack:
       buildable: true
       version: [main]
     libfabric:
+      buildable: false
       externals:
       - spec: libfabric@1.15.2.0
         modules:
         - libfabric/1.15.2.0
-      buildable: true
     autoconf:
       buildable: false
       externals:
@@ -104,3 +104,79 @@ spack:
       externals:
       - spec: json-c@0.13
         prefix: /soft/packaging/spack/gnu-ldpath/build/linux-sles15-x86_64/gcc-11.2.0/json-c-0.13-ykflfo5cmw73w6zvsk4k32bjkjsmpxgn
+    findutils:
+      buildable: false
+      externals: 
+      - spec: findutils@4.8.0
+        prefix: /usr
+    perl:
+      buildable: false
+      externals:
+      - spec: perl@5.26.1~cpanm+opcode+open+shared+threads
+        prefix: /usr
+    gmake:
+      buildable: false
+      externals:
+      - spec: gmake@4.2.1
+        prefix: /usr
+    gawk:
+      buildable: false
+      externals:
+      - spec: gawk@4.2.1
+        prefix: /usr
+    python:
+      buildable: false
+      externals:
+      - spec: python@3.10.10
+        modules:
+        - python/3.10.10
+    groff:
+      buildable: false
+      externals:
+      - spec: groff@1.22.4
+        prefix: /usr
+    curl:
+      buildable: false
+      externals:
+      - spec: curl@7.79.1+gssapi+ldap+nghttp2
+        prefix: /usr
+    openssh:
+      buildable: false
+      externals:
+      - spec: openssh@8.4p1
+        prefix: /usr
+    gettext:
+      buildable: false
+      externals:
+      - spec: gettext@0.20.2
+        prefix: /usr
+    pkg-config:
+      buildable: false
+      externals:
+      - spec: pkg-config@0.29.2
+        prefix: /usr
+    sed:
+      buildable: false
+      externals:
+      - spec: sed@4.4
+        prefix: /usr
+    tar:
+      buildable: false
+      externals:
+      - spec: tar@1.34
+        prefix: /usr
+    binutils:
+      buildable: false
+      externals:
+      - spec: binutils@2.39.0
+        prefix: /usr
+    coreutils:
+      buildable: false
+      externals:
+      - spec: coreutils@8.32
+        prefix: /usr
+    ncurses:
+      buildable: false
+      externals:
+      - spec: ncurses@6.1
+        prefix: /usr


### PR DESCRIPTION
- in particular avoid installing a new python interpreter
- also set buildable to false for libfabric to make sure it uses the system package from HPE