### PR TITLE
Fixed spack.yaml for Polaris

### DIFF
--- a/ANL/Polaris/README.md
+++ b/ANL/Polaris/README.md
@@ -39,17 +39,15 @@ $ qsub ./job.qsub
 
 Notes
 -----
-As of this writing (2023-12-4) it is best to use json-c 0.13 with Mochi in
+As of this writing (2024-07-09) it is best to use json-c 0.13 with Mochi in
 order to ensure link time compatibility with the system json-c used by the
-system libfabric and cray-mpich on Polaris. However, the json-c-devel
-package is not installed on Polaris at this time, and 0.13 is not available
-in upstream Spack, so this is a difficult combination to use for Mochi.
+system libfabric and cray-mpich on Polaris.  This spack.yaml example uses a
+`require:` directective to enforce this constraint.  Note that json-c 0.13 is
+not available upstream in spack; it is provided as part of the
+mochi-spack-packages repository.
 
-As a workaround, the mochi-spack-packages repo adds an additional json-c
-version (labeled 0.13.0 to disambiguate from 0.13.1 which is already in
-Spack).  We also add a dependency in the root spec in the spack.yaml to
-ensure that this version is used on Polaris.
-
-These instructions and environment examples will be updated if/when a
-matching json-c-devel package is installed on Polaris in the system
-environment.
+These instructions and environment examples will be updated if a matching
+json-c-devel package is installed on Polaris (in which case we can use it as an
+external package) or the system-provided libfabric package is built against a
+newer version of json-c (in which case Mochi will be able to use a newer json-c
+as well).

--- a/ANL/Polaris/spack.yaml
+++ b/ANL/Polaris/spack.yaml
@@ -45,7 +45,7 @@ spack:
       require:
       - cray-mpich
     pkgconfig:
-      requires:
+      require:
       - pkg-config
     cray-mpich:
       buildable: false

--- a/ANL/Polaris/spack.yaml
+++ b/ANL/Polaris/spack.yaml
@@ -38,11 +38,11 @@ spack:
       extra_rpaths: []
   packages:
     all:
-      requires:
+      require:
       - "%gcc@12.3"
       - "target=zen3"
     mpi:
-      requires:
+      require:
       - cray-mpich
     pkgconfig:
       requires:

--- a/ANL/Polaris/spack.yaml
+++ b/ANL/Polaris/spack.yaml
@@ -44,6 +44,9 @@ spack:
     mpi:
       require:
       - cray-mpich
+    json-c:
+      require:
+      - "@0.13.0"
     pkgconfig:
       require:
       - pkg-config

--- a/ANL/Polaris/spack.yaml
+++ b/ANL/Polaris/spack.yaml
@@ -5,16 +5,16 @@
 spack:
   # add package specs to the `specs` list
   specs:
-  - mochi-margo^json-c@0.13.0
+  - mochi-margo
   view: true
   modules:
     prefix_inspections:
       lib: [LD_LIBRARY_PATH]
       lib64: [LD_LIBRARY_PATH]
-#  mirrors:
-#    mochi-buildcache:
-#      url: oci://ghcr.io/mochi-hpc/mochi-spack-buildcache
-#      signed: false
+  mirrors:
+    mochi-buildcache:
+      url: oci://ghcr.io/mochi-hpc/mochi-spack-buildcache
+      signed: false
   config:
     install_tree:
       padded_length: 128
@@ -38,13 +38,15 @@ spack:
       extra_rpaths: []
   packages:
     all:
-      providers:
-        mpi: [ cray-mpich ]
-        pkgconfig: [ pkg-config ]
-      compiler:
-      - gcc@12.3
-      target:
-      - zen3
+      requires:
+      - "%gcc@12.3"
+      - "target=zen3"
+    mpi:
+      requires:
+      - cray-mpich
+    pkgconfig:
+      requires:
+      - pkg-config
     cray-mpich:
       buildable: false
       externals:


### PR DESCRIPTION
This PR re-enables the build cache for Polaris and fixes the problem seen by @carns where spack would try to use openmpi instead of cray-mpich. It also adds git as external (git has a lot of dependencies and right now spack fails to build the krb5 dependency for it).

Note: a run of mofka in CI on Polaris has populated the cache with a lot of "%gcc@12.3 target=zen3" dependencies, so this spack.yaml file should be able to find many dependencies in the cache.

This PR should solve https://github.com/mochi-hpc-experiments/platform-configurations/issues/38. 