### PR TITLE
WIP: use HPE Python build and OS Perl build on Polaris

### DIFF
--- a/ANL/Polaris/spack.yaml
+++ b/ANL/Polaris/spack.yaml
@@ -115,3 +115,14 @@ spack:
       externals:
       - spec: git@2.35.3
         prefix: /usr
+    perl:
+      buildable: false
+      externals:
+      - spec: perl@5.26.1
+        prefix: /usr
+    python:
+      buildable: false
+      externals:
+      - spec: python@3.11.5
+        modules:
+        - cray-python/3.11.5


### PR DESCRIPTION
I'm not sure of the overall pros and cons or side effects of doing this vs. using Spack-built packages and/or the buildcache.  The PR is for discussion.

It trims off some dependencies to save build time (if not using buildcache) or downloads/installs (if using buildcache).

@mdorier @GueroudjiAmal
