### PR TITLE
WIP: update Slingshot usage information

### DIFF
--- a/ANL/Aurora/README.md
+++ b/ANL/Aurora/README.md
@@ -5,44 +5,39 @@ Aurora
 Programming environment
 -----------------------
 
-This documentation is for the Aurora system at the ALCF as of October 2024.
-We anticipate that the system environment will still change through the
-friendly early access program.
-
-These instructions assume the use of the default Intel oneAPI compiler.
+We recommend using the system-provided GNU compiler as specified in the
+example Spack configurations.
 
 Networking
 ----------
 
-Aurora will use the Slingshot `cxi://` transport in Mercury. The example Spack
-environment file is already configured to use the appropriate system-provided
-libfabric library to gain CXI support.  Upstream versions of libfabric compiled
-from source do not support this transport.
+Polaris will use the `ofi+cxi://` transport in Mercury for native access to
+the Slingshot network. We recommend using the system-provided modules for
+both libfabric and MPICH.
 
 Process placement
 -----------------
 
 Aurora nodes have 2 sockets, each with 52 cores, however core 0 and core 52
-should be avoided as they may run service processes. Hence, 102 cores are available
-in total. To bind ranks to the proper cores, use `--cpu-bind list:...` with an
-explicit list of comma-separated cores for every colon-separated rank.
-For instance, `--cpu-bind list:1,2:3,4` maps two ranks to four cores, the first
-rank is mapped to cores 1 and 2, the second to cores 3 and 4.
+are reserved to run service processes. Hence, 102 cores are available
+in total.  See the man page for `mpiexec` for common process binding
+options.
 
-The `make-cpu-bind-list.sh` file in this folder can be used to create the list
-for a desired number of processes. For instance `./make-cpu-bind-list.sh 8` will
-generate a core mapping for 8 ranks. 4 will be placed on each socket, and each
-rank will be mapped to as many cores as possible.
+You can also use the `make-cpu-bind-list.sh` script in this directory to
+generate an explicit binding list for a desired number of processes.  For
+instance `./make-cpu-bind-list.sh 8` will generate a core mapping for 8
+ranks. 4 will be placed on each socket, and each rank will be mapped to as
+many cores as possible.
 
-Note that the list will also contain numbers greater than 104; this is because
-the list actually maps ranks to hyperthreads, with core `n` containing hyperthreads
-`n` and `n+104`.
+Note that the list will also contain numbers greater than 104; this is
+because the list actually maps ranks to hyperthreads, with core `n`
+containing hyperthreads `n` and `n+104`.
 
 Job management
 --------------
 
-Aurora uses the PBS Pro workload manager.  `job.pbs` is an example of job
-file. Please modify the header to use your project allocation and set
+Aurora uses the PBS Pro workload manager.  See `job.pbs` for an example job
+script. Please modify the header to use your project allocation and set
 relevant parameters. You can refer to ALCF documentation for more
 information.
 
@@ -52,3 +47,29 @@ Once modified, the job script may be submitted as follows.
 $ qsub ./job.pbs
 ```
 
+Notes on Slingshot network usage
+--------------------------------
+
+Mochi cannot activate the Slingshot network on Aurora unless the resource
+manager allocates a VNI (virtual network interface) for it to use.  We
+therefore recommend the following; see job.qsub for a concrete example:
+* All processes (even if they are to be executed on the local node in a
+  script) must be launched using `mpiexec`.
+* Use the `--single-node-vni` option to mpiexec to ensure that it allocates
+  a VNI in all cases.
+* Set the `PALS_LOCAL_LAUNCH=0` to work around a PALS bug that prevents the
+  above option from working correctly for processes launched on the local
+  node.
+* Use mochi-margo version 0.21.0 or later for improved VNI handling and
+  better load balancing of traffic across available network cards.
+
+The above recommendations will enable all processes launched within a given
+job allocation to communicate with each other, whether they are launched
+simultaneously with one `mpiexec` command or lauched separately with
+distinct `mpiexec` commands.
+
+Note that as of this writing (September 2025) you also have the option to
+use the default system VNI on Aurora, which permits communication between
+any processes on the system.  To use this mode, use `--no-vni` rather than
+`--single-node-vni` when launching processes with `mpiexec`, or you can
+launch processes directly without mpiexec.

--- a/ANL/Aurora/job.pbs
+++ b/ANL/Aurora/job.pbs
@@ -22,14 +22,6 @@ echo "Activating env"
 spack env activate aurora-demo
 spack find -fN
 
-NNODES=`wc -l < $PBS_NODEFILE`
-NRANKS=1          # Number of MPI ranks per node
-NDEPTH=104        # Number of hardware threads per rank, spacing between MPI ranks on a node
-
-NTOTRANKS=$(( NNODES * NRANKS ))
-
-echo "NUM_NODES=${NNODES}  TOTAL_RANKS=${NTOTRANKS}  RANKS_PER_NODE=${NRANKS}"
-
 # possibly useful environment variables; more testing is needed
 
 # export FI_CXI_OPTIMIZED_MRS=0
@@ -39,8 +31,37 @@ echo "NUM_NODES=${NNODES}  TOTAL_RANKS=${NTOTRANKS}  RANKS_PER_NODE=${NRANKS}"
 # export FI_CXI_REQ_BUF_SIZE=8388608
 # export FI_CXI_DEFAULT_CQ_SIZE=16384
 # export FI_CXI_OFLOW_BUF_SIZE=8388608
-# export FI_CXI_CQ_FILL_PERCENT=20 
+# export FI_CXI_CQ_FILL_PERCENT=20
 
-mpiexec -np ${NTOTRANKS} -ppn ${NRANKS} -d ${NDEPTH} --cpu-bind depth -envall /home/carns/working/install-aurora/bin/margo-p2p-bw -x 8388608 -n "cxi://" -c 8 -D 20
+# This option ensures that the resource manager will allocate Slingshot VNI
+# resources even if it detects that all of the processes launched by a given
+# mpiexec command are on the same node.  This is important for use cases
+# where Mochi servers or clients are started individually.
+VNI_OPTS=--single-node-vni
+# Alternatively, on Aurora you also (for now at least) have the option to
+# disable VNI allocation entirely.  In this case, Mochi will use the default
+# system service that permits communication between any processes on the
+# system.
+# VNI_OPTS=--no-vni
+
+# Note that Aurora defaults to binding each process to a single thread,
+# which will hinder performance if your Mochi processes are multithreaded.
+# The following will disable CPU binding entirely, but you can also consult
+# the mpiexec man page for more possibilities.
+BINDING_OPTS="--cpu-bind none"
+
+# Note that as of September 2025, the PALS service on Aurora has a bug that
+# prevents it from honoring the "--single-node-vni" option described above
+# for processes that are launched on the local node.  The following
+# workaround restores the correct semantic.
+export PALS_LOCAL_LAUNCH=0
+
+# Note that Margo versions 0.21.0 or later will automatically select an
+# appropriate network card from those available on each node.  You could
+# also explicitly select a specific card by using a format like
+# "cxi://cxi0".
+ADDRESS="cxi://"
+
+mpiexec -np 2 -ppn 1 ${VNI_OPTS} ${BINDING_OPTS} /home/carns/working/install-aurora/bin/margo-p2p-bw -x 8388608 -n ${ADDRESS} -c 8 -D 20
 
 

--- a/ANL/Polaris/README.md
+++ b/ANL/Polaris/README.md
@@ -6,7 +6,7 @@ Programming environment
 -----------------------
 
 We recommend using the system-provided GNU compiler as specified in the
-example spack configurations.  The GNU compiler can also be loaded in
+example Spack configurations.  The GNU compiler can also be loaded in
 your normal terminal environment (outside of Spack) by running `module
 swap PrgEnv-nvidia PrgEnv-gnu`.
 
@@ -14,18 +14,14 @@ Networking
 ----------
 
 Polaris will use the `ofi+cxi://` transport in Mercury for native access to
-the Slingshot network. The default environment includes a libfabric package
-that is already properly configured to use it.  Note that this is only
-available using the system libfabric libraries on Polaris; CXI (Slingshot)
-support is not available in the upstream open source libfabric package.
-
-This Spack environment also relies on system CUDA and Cray MPICH libraries.
+the Slingshot network. We recommend using the system-provided modules for
+both libfabric and MPICH.
 
 Job management
 --------------
 
-Polaris uses the PBS Pro workload manager.  `job.qsub` is an example of job
-file. Please modify the header to use your project allocation and set
+Polaris uses the PBS Pro workload manager.  See `job.qsub` for an example
+job script. Please modify the header to use your project allocation and set
 relevant parameters. You can refer to ALCF documentation for more
 information.
 
@@ -34,3 +30,28 @@ Once modified, the job script may be submitted as follows.
 ```
 $ qsub ./job.qsub
 ```
+
+Notes on Slingshot network usage
+--------------------------------
+
+Mochi cannot activate the Slingshot network on Polaris unless the resource
+manager allocates a VNI (virtual network interface) for it to use.  We
+therefore recommend the following; see job.qsub for a concrete example:
+* All processes (even if they are to be executed on the local node in a
+  script) must be launched using `mpiexec`.
+* Use the `--single-node-vni` option to mpiexec to ensure that it allocates
+  a VNI in all cases.
+* Set the `PALS_LOCAL_LAUNCH=0` to work around a PALS bug that prevents the
+  above option from working correctly for processes launched on the local
+  node.
+* Use mochi-margo version 0.21.0 or later for improved VNI handling and
+  better load balancing of traffic across available network cards.
+
+The above recommendations will enable all processes launched within a given
+job allocation to communicate with each other, whether they are launched
+simultaneously with one `mpiexec` command or lauched separately with
+distinct `mpiexec` commands.
+
+There is no mechanism to communicate *across* separate job allocations at
+this time.  This functionality would require configuration and deployment of
+the `drc2` service by the facility/vendor.

--- a/ANL/Polaris/job.qsub
+++ b/ANL/Polaris/job.qsub
@@ -17,10 +17,29 @@ echo "Activating env"
 spack env activate polaris-demo
 spack find -fN
 
-# IMPORANT NOTE: the --cpu-bind none option to mpiexec is crucial if you
-# intend to run Mochi processes that will use additional threads or
-# execution streams.  The default CPU binding on Polaris will limit each
-# process launched with mpiexec to a single CPU core that will starve any
-# additional threads.
-mpiexec -n 2 --ppn 1 --cpu-bind none /home/carns/working/install-polaris/bin/margo-p2p-bw -x 8388608 -n "cxi://" -c 8 -D 20
+# This option ensures that the resource manager will allocate Slingshot VNI
+# resources even if it detects that all of the processes launched by a given
+# mpiexec command are on the same node.  This is important for use cases
+# where Mochi servers or clients are started individually.
+VNI_OPTS=--single-node-vni
+
+# Note that Polaris defaults to binding each process to a single thread,
+# which will hinder performance if your Mochi processes are multithreaded.
+# The following will disable CPU binding entirely, but you can also consult
+# the mpiexec man page for more possibilities.
+BINDING_OPTS="--cpu-bind none"
+
+# Note that as of September 2025, the PALS service on Polaris has a bug that
+# prevents it from honoring the "--single-node-vni" option described above
+# for processes that are launched on the local node.  The following
+# workaround restores the correct semantic.
+export PALS_LOCAL_LAUNCH=0
+
+# Note that Margo versions 0.21.0 or later will automatically select an
+# appropriate network card from those available on each node.  You could
+# also explicitly select a specific card by using a format like
+# "cxi://cxi0".
+ADDRESS="cxi://"
+
+mpiexec -n 2 --ppn 1 ${VNI_OPTS} ${BINDING_OPTS} /home/carns/working/install-polaris/bin/margo-p2p-bw -x 8388608 -n ${ADDRESS} -c 8 -D 20
 

--- a/NERSC/Perlmutter/README.md
+++ b/NERSC/Perlmutter/README.md
@@ -16,23 +16,41 @@ Networking
 ----------
 
 Perlmutter will use the `ofi+cxi://` transport in Mercury for native access to
-the Slingshot network. The default environment includes a libfabric package
-that is already properly configured to use it.  Note that this is only
-available using the system libfabric libraries on Perlmutter; CXI (Slingshot)
-support is not available in the upstream open source libfabric package.
-
+the Slingshot network. We recommend using the system-provided modules for
+both libfabric and MPICH.
 
 Job management
 --------------
 
-Perlmutter uses slurm for scheduling and job management.  See `job.sbatch`
-in this directory for an example job script that launches a Mochi benchmark.
-Please modify the header to use your project allocation and set relevant
-parameters. You can refer to NERSC documentation for more information about
-running jobs.
+Perlmutter uses SLURM for scheduling and job management.  See `job.sbatch` for
+an example job script.  Please modify the header to use your project
+allocation and set relevant parameters. You can refer to NERSC documentation
+for more information.
 
 Once modified, the job script may be submitted as follows.
 
 ```
 $ sbatch job.sbatch
 ```
+
+Notes on Slingshot network usage
+--------------------------------
+
+Mochi cannot activate the Slingshot network on Perlmutter unless the resource
+manager allocates a VNI (virtual network interface) for it to use.  We
+therefore recommend the following; see job.slurm for a concrete example:
+* All processes (even if they are to be executed on the local node in a
+  script) must be launched using `srun`.
+* Use the `--nework job_vni,single_node_vni` option to `srun` to ensure that
+  it allocates a job level VNI in all cases.
+* Use mochi-margo version 0.21.0 or later for improved VNI handling and
+  better load balancing of traffic across available network cards.
+
+The above recommendations will enable all processes launched within a given
+job allocation to communicate with each other, whether they are launched
+simultaneously with one `srun` command or lauched separately with
+distinct `srun` commands.
+
+There is no mechanism to communicate *across* separate job allocations at
+this time.  This functionality would require configuration and deployment of
+the `drc2` service by the facility/vendor.

--- a/NERSC/Perlmutter/job.sbatch
+++ b/NERSC/Perlmutter/job.sbatch
@@ -12,4 +12,19 @@ spack env activate perlmutter-demo
 # confirm what packages are available
 spack find -vN
 
-srun -n 2 /global/homes/p/pcarns/working/install-perlmutter/bin/margo-p2p-bw -x 8388608 -n "cxi://" -c 8 -D 20
+# These two options request that a) SLURM allocate a VNI that spans across
+# the job allocation (not just this mpiexec invocation) and b) that it
+# allocate VNI resources even if it detects that all of the processes
+# launched by a given mpiexec command are on the same node.  This is
+# important for use cases where Mochi servers or clients are started
+# individually.
+VNI_OPTS="--network job_vni,single_node_vni"
+
+# Note that Margo versions 0.21.0 or later will automatically select an
+# appropriate network card from those available on each node.  You could
+# also explicitly select a specific card by using a format like
+# "cxi://cxi0".
+ADDRESS="cxi://"
+
+
+srun -n 2 --ntasks-per-node=1 ${VNI_OPTS} /global/homes/p/pcarns/working/install-perlmutter/bin/margo-p2p-bw -x 8388608 -n ${ADDRESS} -c 8 -D 20

--- a/ORNL/Frontier/README.md
+++ b/ORNL/Frontier/README.md
@@ -15,20 +15,42 @@ $ module swap PrgEnv-cray PrgEnv-gnu
 Networking
 ----------
 
-Mercury should use the `cxi` transport method in Mercury in order to utilize
-the native Cray Slingshot network interface.  If you use "cxi://" as the
-initialization string without specifying a specific NIC, then Mercury will
-select the one that is "closest" to the process in terms of bus locality.
-
-Each Frontier compute node has 4 NICs (see OLCF documentation).
-can be selected manually by using a specification of the form "cxi://cxi0".
-
-It is important to use the vendor-provided libfabric library available in
-the default software environment rather than compiling one with Spack in
-order to have full Slingshot network support.
+Frontier will use the `ofi+cxi://` transport in Mercury for native access to
+the Slingshot network. We recommend using the system-provided modules for
+both libfabric and MPICH.
 
 Job management
 --------------
 
-Frontier uses slurm for scheduling and job management.  See the `job.slurm`
-script in this directory for an example.
+Frontier uses SLURM for scheduling and job management.  See `job.sbatch` for
+an example job script.  Please modify the header to use your project
+allocation and set relevant parameters. You can refer to OLCF documentation
+for more information.
+
+Once modified, the job script may be submitted as follows.
+
+```
+$ sbatch job.sbatch
+```
+
+Notes on Slingshot network usage
+--------------------------------
+
+Mochi cannot activate the Slingshot network on Frontier unless the resource
+manager allocates a VNI (virtual network interface) for it to use.  We
+therefore recommend the following; see job.slurm for a concrete example:
+* All processes (even if they are to be executed on the local node in a
+  script) must be launched using `srun`.
+* Use the `--nework job_vni,single_node_vni` option to `srun` to ensure that
+  it allocates a job level VNI in all cases.
+* Use mochi-margo version 0.21.0 or later for improved VNI handling and
+  better load balancing of traffic across available network cards.
+
+The above recommendations will enable all processes launched within a given
+job allocation to communicate with each other, whether they are launched
+simultaneously with one `srun` command or lauched separately with
+distinct `srun` commands.
+
+There is no mechanism to communicate *across* separate job allocations at
+this time.  This functionality would require configuration and deployment of
+the `drc2` service by the facility/vendor.

--- a/ORNL/Frontier/job.sbatch
+++ b/ORNL/Frontier/job.sbatch
@@ -15,8 +15,18 @@ spack env activate frontier-demo
 # confirm what packages are available
 spack find -vN
 
-# NOTE: by using cxi:// as the address string without specifying which NIC
-# to use, we are allowing Mercury to select the one closest to the process
-# in terms of bus locality.  Frontier has 4 NICs per node that are each
-# conneted to the same fabric.
-srun -n 2 --ntasks-per-node=1 /ccs/home/carns/working/install-frontier/bin/margo-p2p-bw -x 8388608 -n "cxi://" -c 8 -D 20
+# These two options request that a) SLURM allocate a VNI that spans across
+# the job allocation (not just this mpiexec invocation) and b) that it
+# allocate VNI resources even if it detects that all of the processes
+# launched by a given mpiexec command are on the same node.  This is
+# important for use cases where Mochi servers or clients are started
+# individually.
+VNI_OPTS="--network job_vni,single_node_vni"
+
+# Note that Margo versions 0.21.0 or later will automatically select an
+# appropriate network card from those available on each node.  You could
+# also explicitly select a specific card by using a format like
+# "cxi://cxi0".
+ADDRESS="cxi://"
+
+srun -n 2 --ntasks-per-node=1 ${VNI_OPTS} /ccs/home/carns/working/install-frontier/bin/margo-p2p-bw -x 8388608 -n ${ADDRESS} -c 8 -D 20


### PR DESCRIPTION
- all 4 of Polaris, Perlmutter, Aurora, and Frontier
- recommend 0.21.0 of Margo
- more clearly document CXI options
- update example scripts to follow recommended practice

This should be merged after Margo version 0.21.0 is tagged and available in mochi-spack-packages.